### PR TITLE
[chore] do not run collect splunk-pod-logs always in the Splunk integration test pipeline

### DIFF
--- a/.github/workflows/functional_test.yaml
+++ b/.github/workflows/functional_test.yaml
@@ -141,7 +141,7 @@ jobs:
           retention-days: 5
 
       - name: Print splunk-otel-collector logs
-        if: always()
+        if: always() && steps.run-functional-tests.outcome == 'failure'
         run: |
           # Echo logs for the collector (agent,cluster-receiver,gateway) for visibility
           pods=$(kubectl get pods -l app=splunk-otel-collector -o jsonpath='{.items[*].metadata.name}')


### PR DESCRIPTION
**Description:** 
Fix for a situation where the Splunk setup failed and we attempted to collect logs, but it was not possible because the Splunk pod did not start due to a Minikube setup issue. 
Now, we will trigger the log collection step if there is a failure in the functional test run step.


